### PR TITLE
[Feat] #18 - RecallView TableView로 전환

### DIFF
--- a/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS.xcodeproj/project.pbxproj
+++ b/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		144624F42A1BDC1F008EAE22 /* DatePickerControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144624F32A1BDC1F008EAE22 /* DatePickerControl.swift */; };
+		146BBB4A2A17EEEB00A6C21A /* RecommendRoutineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146BBB492A17EEEB00A6C21A /* RecommendRoutineViewController.swift */; };
+		146BBB4D2A17F0DF00A6C21A /* TotalRoutineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146BBB4C2A17F0DF00A6C21A /* TotalRoutineViewController.swift */; };
+		146BBB542A18D6CF00A6C21A /* TotalRoutineTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146BBB532A18D6CF00A6C21A /* TotalRoutineTableViewCell.swift */; };
+		146BBB562A18DC5600A6C21A /* NSObject+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146BBB552A18DC5600A6C21A /* NSObject+.swift */; };
+		146BBB5A2A18E7A000A6C21A /* TotalRoutineHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146BBB592A18E79F00A6C21A /* TotalRoutineHeaderView.swift */; };
+		148675B52A1CDE630082D579 /* DatePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148675B42A1CDE630082D579 /* DatePickerViewController.swift */; };
 		148675B72A1D08A00082D579 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148675B62A1D08A00082D579 /* Config.swift */; };
 		148675B92A1D0A9D0082D579 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148675B82A1D0A9D0082D579 /* NetworkResult.swift */; };
 		148675BB2A1D0AFF0082D579 /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148675BA2A1D0AFF0082D579 /* APIConstants.swift */; };
@@ -30,13 +37,8 @@
 		251030B02A1C8C7B00AD5292 /* EditRecallViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 251030AF2A1C8C7B00AD5292 /* EditRecallViewController.swift */; };
 		25491B502A17ADF800B16FA8 /* Customnavigationbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25491B4F2A17ADF800B16FA8 /* Customnavigationbar.swift */; };
 		25491B532A189DF200B16FA8 /* AchieveViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25491B522A189DF200B16FA8 /* AchieveViewController.swift */; };
-		144624F42A1BDC1F008EAE22 /* DatePickerControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144624F32A1BDC1F008EAE22 /* DatePickerControl.swift */; };
-		146BBB4A2A17EEEB00A6C21A /* RecommendRoutineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146BBB492A17EEEB00A6C21A /* RecommendRoutineViewController.swift */; };
-		146BBB4D2A17F0DF00A6C21A /* TotalRoutineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146BBB4C2A17F0DF00A6C21A /* TotalRoutineViewController.swift */; };
-		146BBB542A18D6CF00A6C21A /* TotalRoutineTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146BBB532A18D6CF00A6C21A /* TotalRoutineTableViewCell.swift */; };
-		146BBB562A18DC5600A6C21A /* NSObject+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146BBB552A18DC5600A6C21A /* NSObject+.swift */; };
-		146BBB5A2A18E7A000A6C21A /* TotalRoutineHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146BBB592A18E79F00A6C21A /* TotalRoutineHeaderView.swift */; };
-		148675B52A1CDE630082D579 /* DatePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148675B42A1CDE630082D579 /* DatePickerViewController.swift */; };
+		25679F862A1FB01C0051F842 /* RecallFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25679F852A1FB01C0051F842 /* RecallFooterView.swift */; };
+		25679F882A1FB0430051F842 /* RecallTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25679F872A1FB0430051F842 /* RecallTableViewCell.swift */; };
 		6B27D7502A126B5A0033BB21 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B27D74F2A126B5A0033BB21 /* AppDelegate.swift */; };
 		6B27D7522A126B5A0033BB21 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B27D7512A126B5A0033BB21 /* SceneDelegate.swift */; };
 		6B27D7542A126B5A0033BB21 /* MainPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B27D7532A126B5A0033BB21 /* MainPageViewController.swift */; };
@@ -70,6 +72,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		144624F32A1BDC1F008EAE22 /* DatePickerControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerControl.swift; sourceTree = "<group>"; };
+		146BBB492A17EEEB00A6C21A /* RecommendRoutineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendRoutineViewController.swift; sourceTree = "<group>"; };
+		146BBB4C2A17F0DF00A6C21A /* TotalRoutineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalRoutineViewController.swift; sourceTree = "<group>"; };
+		146BBB532A18D6CF00A6C21A /* TotalRoutineTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalRoutineTableViewCell.swift; sourceTree = "<group>"; };
+		146BBB552A18DC5600A6C21A /* NSObject+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+.swift"; sourceTree = "<group>"; };
+		146BBB592A18E79F00A6C21A /* TotalRoutineHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalRoutineHeaderView.swift; sourceTree = "<group>"; };
+		148675B42A1CDE630082D579 /* DatePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerViewController.swift; sourceTree = "<group>"; };
 		148675B62A1D08A00082D579 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Config.swift; path = "MY-SOPT-IN-iOS/Network/Config/Config.swift"; sourceTree = SOURCE_ROOT; };
 		148675B82A1D0A9D0082D579 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NetworkResult.swift; path = "MY-SOPT-IN-iOS/Network/Foundation/NetworkResult.swift"; sourceTree = SOURCE_ROOT; };
 		148675BA2A1D0AFF0082D579 /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = APIConstants.swift; path = "MY-SOPT-IN-iOS/Network/Foundation/APIConstants.swift"; sourceTree = SOURCE_ROOT; };
@@ -92,13 +101,8 @@
 		251030AF2A1C8C7B00AD5292 /* EditRecallViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditRecallViewController.swift; sourceTree = "<group>"; };
 		25491B4F2A17ADF800B16FA8 /* Customnavigationbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Customnavigationbar.swift; path = "MY-SOPT-IN-iOS/Presentation/Component/Customnavigationbar.swift"; sourceTree = SOURCE_ROOT; };
 		25491B522A189DF200B16FA8 /* AchieveViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchieveViewController.swift; sourceTree = "<group>"; };
-		144624F32A1BDC1F008EAE22 /* DatePickerControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerControl.swift; sourceTree = "<group>"; };
-		146BBB492A17EEEB00A6C21A /* RecommendRoutineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendRoutineViewController.swift; sourceTree = "<group>"; };
-		146BBB4C2A17F0DF00A6C21A /* TotalRoutineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalRoutineViewController.swift; sourceTree = "<group>"; };
-		146BBB532A18D6CF00A6C21A /* TotalRoutineTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalRoutineTableViewCell.swift; sourceTree = "<group>"; };
-		146BBB552A18DC5600A6C21A /* NSObject+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+.swift"; sourceTree = "<group>"; };
-		146BBB592A18E79F00A6C21A /* TotalRoutineHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalRoutineHeaderView.swift; sourceTree = "<group>"; };
-		148675B42A1CDE630082D579 /* DatePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerViewController.swift; sourceTree = "<group>"; };
+		25679F852A1FB01C0051F842 /* RecallFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecallFooterView.swift; sourceTree = "<group>"; };
+		25679F872A1FB0430051F842 /* RecallTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecallTableViewCell.swift; sourceTree = "<group>"; };
 		6B27D74C2A126B5A0033BB21 /* MY-SOPT-IN-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MY-SOPT-IN-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B27D74F2A126B5A0033BB21 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		6B27D7512A126B5A0033BB21 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -145,6 +149,42 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		146BBB482A17EEBE00A6C21A /* RecommendRoutine */ = {
+			isa = PBXGroup;
+			children = (
+				146BBB492A17EEEB00A6C21A /* RecommendRoutineViewController.swift */,
+			);
+			path = RecommendRoutine;
+			sourceTree = "<group>";
+		};
+		146BBB4B2A17F0AC00A6C21A /* TotalRoutine */ = {
+			isa = PBXGroup;
+			children = (
+				146BBB582A18E74E00A6C21A /* VC */,
+				146BBB572A18E74400A6C21A /* Views */,
+			);
+			path = TotalRoutine;
+			sourceTree = "<group>";
+		};
+		146BBB572A18E74400A6C21A /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				146BBB532A18D6CF00A6C21A /* TotalRoutineTableViewCell.swift */,
+				146BBB592A18E79F00A6C21A /* TotalRoutineHeaderView.swift */,
+				144624F32A1BDC1F008EAE22 /* DatePickerControl.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		146BBB582A18E74E00A6C21A /* VC */ = {
+			isa = PBXGroup;
+			children = (
+				146BBB4C2A17F0DF00A6C21A /* TotalRoutineViewController.swift */,
+				148675B42A1CDE630082D579 /* DatePickerViewController.swift */,
+			);
+			path = VC;
+			sourceTree = "<group>";
+		};
 		148675BE2A1D0CEB0082D579 /* Foundation */ = {
 			isa = PBXGroup;
 			children = (
@@ -228,6 +268,8 @@
 			isa = PBXGroup;
 			children = (
 				251030AB2A1C8C4F00AD5292 /* RecallView.swift */,
+				25679F852A1FB01C0051F842 /* RecallFooterView.swift */,
+				25679F872A1FB0430051F842 /* RecallTableViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -238,42 +280,6 @@
 				25491B4F2A17ADF800B16FA8 /* Customnavigationbar.swift */,
 			);
 			path = Component;
-			sourceTree = "<group>";
-		};
-		146BBB482A17EEBE00A6C21A /* RecommendRoutine */ = {
-			isa = PBXGroup;
-			children = (
-				146BBB492A17EEEB00A6C21A /* RecommendRoutineViewController.swift */,
-			);
-			path = RecommendRoutine;
-			sourceTree = "<group>";
-		};
-		146BBB4B2A17F0AC00A6C21A /* TotalRoutine */ = {
-			isa = PBXGroup;
-			children = (
-				146BBB582A18E74E00A6C21A /* VC */,
-				146BBB572A18E74400A6C21A /* Views */,
-			);
-			path = TotalRoutine;
-			sourceTree = "<group>";
-		};
-		146BBB572A18E74400A6C21A /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				146BBB532A18D6CF00A6C21A /* TotalRoutineTableViewCell.swift */,
-				146BBB592A18E79F00A6C21A /* TotalRoutineHeaderView.swift */,
-				144624F32A1BDC1F008EAE22 /* DatePickerControl.swift */,
-			);
-			path = Views;
-			sourceTree = "<group>";
-		};
-		146BBB582A18E74E00A6C21A /* VC */ = {
-			isa = PBXGroup;
-			children = (
-				146BBB4C2A17F0DF00A6C21A /* TotalRoutineViewController.swift */,
-				148675B42A1CDE630082D579 /* DatePickerViewController.swift */,
-			);
-			path = VC;
 			sourceTree = "<group>";
 		};
 		6B27D7432A126B5A0033BB21 = {
@@ -580,6 +586,7 @@
 				148675D42A1D29FF0082D579 /* RetroAPI.swift in Sources */,
 				6B822EEE2A17E2220080FB7C /* SelectDateHeaderFooter.swift in Sources */,
 				148675B52A1CDE630082D579 /* DatePickerViewController.swift in Sources */,
+				25679F882A1FB0430051F842 /* RecallTableViewCell.swift in Sources */,
 				6BAFCD302A15438F00994100 /* MainPageRecallViewController.swift in Sources */,
 				6B44E4A52A12A8EB00E9CAF9 /* UITextField+.swift in Sources */,
 				6B8EC7FC2A1CB44400926510 /* MainPageRecallHeaderView.swift in Sources */,
@@ -615,6 +622,7 @@
 				6B27D7522A126B5A0033BB21 /* SceneDelegate.swift in Sources */,
 				146BBB4A2A17EEEB00A6C21A /* RecommendRoutineViewController.swift in Sources */,
 				6B44E49B2A1296A700E9CAF9 /* ColorLiteral.swift in Sources */,
+				25679F862A1FB01C0051F842 /* RecallFooterView.swift in Sources */,
 				148675D02A1D23980082D579 /* TotalRetroResponseDTO.swift in Sources */,
 				251030AC2A1C8C4F00AD5292 /* RecallView.swift in Sources */,
 				148675B72A1D08A00082D579 /* Config.swift in Sources */,

--- a/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS.xcodeproj/project.pbxproj
+++ b/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS.xcodeproj/project.pbxproj
@@ -467,9 +467,9 @@
 			isa = PBXGroup;
 			children = (
 				250DDF452A15B9B3008B8661 /* RoutineView.swift */,
+				6BF052F02A17631E00893084 /* SelectDateCVC.swift */,
 				250C93A02A13A4E0005599DA /* BottomSheetView.swift */,
 				6BAFCD2B2A153C1300994100 /* MainPageTopBarView.swift */,
-				6BF052F02A17631E00893084 /* SelectDateCVC.swift */,
 				6B8EC7F92A1B3B8000926510 /* SelectDateCollectionView.swift */,
 				6B822EED2A17E2220080FB7C /* SelectDateHeaderFooter.swift */,
 				6BF052E12A16B09700893084 /* MainPageRoutineTVC.swift */,

--- a/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/Component/Customnavigationbar.swift
+++ b/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/Component/Customnavigationbar.swift
@@ -50,7 +50,7 @@ class Customnavigationbar: UIView {
         navigationView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(48)
+            $0.height.equalTo(54)
         }
         
         navigationBack.snp.makeConstraints {
@@ -60,7 +60,7 @@ class Customnavigationbar: UIView {
         
         navigationTitle.snp.makeConstraints {
             $0.top.equalTo(navigationView.snp.top).offset(12)
-            $0.centerX.equalTo(navigationView)
+            $0.centerX.centerY.equalTo(navigationView)
         }
     }
 }

--- a/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/MainPage/VC/MainPageRecallViewController.swift
+++ b/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/MainPage/VC/MainPageRecallViewController.swift
@@ -11,10 +11,12 @@ import SnapKit
 import Then
 
 final class MainPageRecallViewController: UIViewController {
-
+    
     // MARK: - Properties
-
+    
     private let headerView = MainPageRecallHeaderView()
+    
+    private let recall = UITableView()
     
     private var dateDummy: [[Dates]] = [Dates.getPreviousDateDummy(),
                                         Dates.dummy(),
@@ -23,6 +25,7 @@ final class MainPageRecallViewController: UIViewController {
     private var headerViewStartPoint: CGFloat = 0
     
     private var selectedDay = Dates.getToday()?.dateComponents
+    
     
     // MARK: - View Life Cycle
     
@@ -34,7 +37,7 @@ final class MainPageRecallViewController: UIViewController {
         setHierarchy()
         setLayout()
     }
-
+    
     // MARK: - Methods
     
     private func target() {
@@ -49,6 +52,16 @@ final class MainPageRecallViewController: UIViewController {
             $0.register(SelectDateHeaderFooter.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: SelectDateHeaderFooter.identifier)
             $0.register(SelectDateHeaderFooter.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: SelectDateHeaderFooter.identifier)
         }
+        
+        recall.dataSource = self
+        recall.delegate = self
+        recall.register(RecallTableViewCell.self, forCellReuseIdentifier: "Cell")
+        recall.register(RecallFooterView.self, forHeaderFooterViewReuseIdentifier: "Footer")
+        recall.separatorColor = .clear
+        recall.tableHeaderView = headerView
+        recall.tableHeaderView?.frame.size.height = 120
+        recall.backgroundColor = .Gray.gray_50
+        recall.showsVerticalScrollIndicator = false
     }
     
     private func setStyle() {
@@ -58,20 +71,26 @@ final class MainPageRecallViewController: UIViewController {
     
     private func setHierarchy() {
         
-        view.addSubviews(headerView)
+        view.addSubviews(
+            recall
+        )
     }
     
     private func setLayout() {
-        
-        headerView.snp.makeConstraints {
-            $0.top.leading.trailing.equalToSuperview()
+        recall.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
-    }
 
+    }
+    
     // MARK: - @objc Function
     
+    @objc private func saveButtonTapped() {
+        // 저장하기 버튼 클릭에 따른 메소드 미구현
+    }
+    
     // MARK: - Network
-
+    
 }
 
 extension MainPageRecallViewController: UICollectionViewDelegate {
@@ -159,4 +178,31 @@ extension MainPageRecallViewController: UIScrollViewDelegate {
         
         headerView.dateScrollView.contentOffset.x = UIScreen.main.bounds.width
     }
+}
+
+extension MainPageRecallViewController: UITableViewDataSource, UITableViewDelegate {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
+        cell.selectionStyle = .none // Disable cell selection highlighting
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        let footerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: "Footer") as? RecallFooterView
+        footerView?.saveButton.addTarget(self, action: #selector(saveButtonTapped), for: .touchUpInside)
+        return footerView
+    }
+    
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return 100
+    }
+    
 }

--- a/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/MainPage/VC/MainPageRecallViewController.swift
+++ b/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/MainPage/VC/MainPageRecallViewController.swift
@@ -53,6 +53,9 @@ final class MainPageRecallViewController: UIViewController {
             $0.register(SelectDateHeaderFooter.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: SelectDateHeaderFooter.identifier)
         }
         
+        headerView.achieveRecallBtn.addTarget(self, action: #selector(moreButtonDidTapped), for: .touchUpInside)
+        
+        
         recall.dataSource = self
         recall.delegate = self
         recall.register(RecallTableViewCell.self, forCellReuseIdentifier: "Cell")
@@ -87,6 +90,13 @@ final class MainPageRecallViewController: UIViewController {
     
     @objc private func saveButtonTapped() {
         // 저장하기 버튼 클릭에 따른 메소드 미구현
+    }
+    
+    @objc
+    private func moreButtonDidTapped() {
+        let totalRoutineVC = TotalRoutineViewController()
+        navigationController?.pushViewController(totalRoutineVC, animated: true)
+        navigationController?.navigationBar.isHidden = true
     }
     
     // MARK: - Network

--- a/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/MainPage/Views/MainPageRecallHeaderView.swift
+++ b/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/MainPage/Views/MainPageRecallHeaderView.swift
@@ -21,7 +21,7 @@ class MainPageRecallHeaderView: UIView {
                                     nextSelectDateCollectionView]
     
     private var dateView = UIView()
-    private var achieveRecallBtn = UIButton()
+    lazy var achieveRecallBtn = UIButton()
     var dateLabel = UILabel()
     
     private let screenWidth = UIScreen.main.bounds.width

--- a/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/MainPage/Views/MainPageRecallHeaderView.swift
+++ b/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/MainPage/Views/MainPageRecallHeaderView.swift
@@ -60,6 +60,10 @@ class MainPageRecallHeaderView: UIView {
             $0.setTitle("회고 모아보기", for: .normal)
             $0.setTitleColor(.Gray.gray_800, for: .normal)
             $0.titleLabel?.font = .subtitleFont()
+            let deleteImage = ImageLiterals.RecallProperty.moreRecall
+            $0.setImage(deleteImage, for: .normal)
+            $0.imageEdgeInsets = UIEdgeInsets(top: 0, left: -4, bottom: 0, right: 6)
+
 
         }
     }

--- a/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/MainPage/Views/RoutineView.swift
+++ b/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/MainPage/Views/RoutineView.swift
@@ -72,7 +72,7 @@ class RoutineView: UIView {
     }
     
     private let routineImage = UIImageView().then {
-        $0.image = ImageLiterals.Icon.add_ic_calender
+        $0.image = ImageLiterals.Icon.add_ic_calendar
     }
     
     private let routineLabel = UILabel().then {
@@ -493,7 +493,7 @@ class RoutineView: UIView {
         
         saveroutineButton.snp.makeConstraints {
             $0.bottom.equalToSuperview()
-            $0.width.equalTo(375)
+            $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(71)
         }
     }

--- a/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/RecallPage/VC/EditRecallViewController.swift
+++ b/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/RecallPage/VC/EditRecallViewController.swift
@@ -29,10 +29,6 @@ class EditRecallViewController: UIViewController {
         $0.textColor = UIColor.Gray.gray_800
     }
     
-    private let privateButton = UIButton().then {
-        $0.setImage(ImageLiterals.RecallProperty.defaultRecall, for: .normal)
-    }
-    
     private let saverecallButton = UIButton().then() {
         $0.setTitle("저장하기", for: .normal)
         $0.titleLabel?.font = UIFont.subtitleFont()
@@ -59,7 +55,6 @@ class EditRecallViewController: UIViewController {
             addNavigationbar,
             backcolor,
             editdateLabel,
-            privateButton,
             recallView,
             saverecallButton
         )
@@ -79,11 +74,6 @@ class EditRecallViewController: UIViewController {
             $0.leading.equalToSuperview().offset(16)
         }
         
-        privateButton.snp.makeConstraints {
-            $0.trailing.equalToSuperview().offset(-19)
-            $0.centerY.equalTo(editdateLabel)
-        }
-        
         recallView.snp.makeConstraints {
             $0.top.equalTo(addNavigationbar.snp.bottom).offset(55)
             $0.bottom.equalToSuperview()
@@ -92,7 +82,7 @@ class EditRecallViewController: UIViewController {
         
         saverecallButton.snp.makeConstraints {
             $0.bottom.equalToSuperview()
-            $0.width.equalTo(375)
+            $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(71)
         }
     }

--- a/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/RecallPage/VC/RecallViewController.swift
+++ b/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/RecallPage/VC/RecallViewController.swift
@@ -10,27 +10,26 @@ import SnapKit
 import Then
 
 
-
 class RecallViewController: UIViewController {
-    
+
     private let scrollView = UIScrollView().then {
         $0.showsVerticalScrollIndicator = false
     }
-    
+
     private let contentView = UIView()
-    
+
     private let recallView = RecallView()
-    
-    private let privateButton = UIButton().then {
-        $0.setImage(ImageLiterals.RecallProperty.defaultRecall, for: .normal)
-    }
-    
+
+//    private let privateButton = UIButton().then {
+//        $0.setImage(ImageLiterals.RecallProperty.defaultRecall, for: .normal)
+//    }
+
     private let recalldateLabel = UILabel().then {
         $0.text = "2023년 5월 7일"
         $0.font = UIFont.title2Font()
         $0.textColor = UIColor.Gray.gray_800
     }
-    
+
     private let moreLabel = UIButton().then {
         $0.setTitle("회고 모아보기", for: .normal)
         $0.setTitleColor(UIColor.Gray.gray_800, for: .normal)
@@ -41,7 +40,7 @@ class RecallViewController: UIViewController {
         $0.addTarget(self, action: #selector(pushToEditRecall), for: .touchUpInside)
 
     }
-    
+
     private let saveButton = UIButton().then {
         $0.setTitle("저장하기", for: .normal)
         $0.setTitleColor(UIColor.Gray.gray_900, for: .normal)
@@ -52,61 +51,61 @@ class RecallViewController: UIViewController {
         $0.layer.borderWidth = 1
         $0.layer.borderColor = UIColor.Primary.primary_700.cgColor
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         view.backgroundColor = UIColor.Gray.gray_50
-        
+
         view.addSubview(scrollView)
         scrollView.addSubview(contentView)
         contentView.addSubviews(
             recalldateLabel,
             moreLabel,
             recallView,
-            privateButton,
+//            privateButton,
             saveButton
         )
-        
+
         recallView.recallTextView.delegate = self
         recallView.bestTextView.delegate = self
         recallView.wantsayTextView.delegate = self
-        
+
         setupConstraints()
     }
-    
+
     private func setupConstraints() {
-        
+
         scrollView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
-        
+
         contentView.snp.makeConstraints {
             $0.edges.equalToSuperview()
             $0.width.equalToSuperview()
             $0.height.equalTo(710) // 스크롤 뷰의 높이 설정
         }
-        
+
         recalldateLabel.snp.makeConstraints {
             $0.bottom.equalTo(recallView.recallTextView.snp.top).offset(-57)
             $0.leading.equalToSuperview().offset(16)
         }
-        
+
         moreLabel.snp.makeConstraints {
             $0.trailing.equalToSuperview().offset(-19)
             $0.centerY.equalTo(recalldateLabel)
         }
-        
+
         recallView.snp.makeConstraints {
             $0.top.equalTo(recalldateLabel.snp.bottom).offset(57)
             $0.leading.trailing.equalToSuperview()
         }
-        
-        privateButton.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(18)
-            $0.bottom.equalTo(recallView.recallTextView.snp.top).offset(-10)
-        }
-        
+
+//        privateButton.snp.makeConstraints {
+//            $0.trailing.equalToSuperview().inset(18)
+//            $0.bottom.equalTo(recallView.recallTextView.snp.top).offset(-10)
+//        }
+
         saveButton.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(26)
             $0.top.equalTo(recallView.wantsayTextView.snp.bottom).offset(17)
@@ -114,14 +113,14 @@ class RecallViewController: UIViewController {
             $0.height.equalTo(42)
         }
     }
-    
+
     @objc
     private func pushToEditRecall() {
         let editreacallViewController = EditRecallViewController()
         editreacallViewController.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(editreacallViewController, animated: true)
     }
-    
+
 }
 
 
@@ -146,7 +145,7 @@ extension RecallViewController: UITextViewDelegate {
             }
         }
     }
-    
+
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView == recallView.recallTextView {
             if textView.text.isEmpty {

--- a/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/RecallPage/View/RecallFooterView.swift
+++ b/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/RecallPage/View/RecallFooterView.swift
@@ -1,0 +1,49 @@
+//
+//  RecallFooterView.swift
+//  MY-SOPT-IN-iOS
+//
+//  Created by 천성우 on 2023/05/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class RecallFooterView: UITableViewHeaderFooterView {
+    
+    let saveButton = UIButton().then {
+        $0.setTitle("저장하기", for: .normal)
+        $0.setTitleColor(UIColor.Gray.gray_900, for: .normal)
+        $0.titleLabel?.font = UIFont.body2Font()
+        $0.backgroundColor = UIColor.Primary.primary
+        $0.layer.cornerRadius = 20
+        $0.clipsToBounds = true
+        $0.layer.borderWidth = 1
+        $0.layer.borderColor = UIColor.Primary.primary_700.cgColor
+    }
+    
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupViews()
+    }
+    
+    private func setupViews() {
+        contentView.backgroundColor = .Gray.gray_50
+        addSubview(saveButton)
+        saveButton.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(17)
+            $0.trailing.equalToSuperview().inset(15)
+            $0.width.equalTo(69)
+            $0.height.equalTo(42)
+        }
+        
+        contentView.layer.borderWidth = 0  // 테두리 제거
+        contentView.layer.borderColor = UIColor.clear.cgColor
+    }
+}

--- a/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/RecallPage/View/RecallTableViewCell.swift
+++ b/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/RecallPage/View/RecallTableViewCell.swift
@@ -1,0 +1,35 @@
+//
+//  RecallTableViewCell.swift
+//  MY-SOPT-IN-iOS
+//
+//  Created by 천성우 on 2023/05/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class RecallTableViewCell: UITableViewCell {
+    
+    let recallView = RecallView()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupViews()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        setupViews()
+    }
+    
+    private func setupViews() {
+        contentView.addSubview(recallView)
+        recallView.snp.makeConstraints {
+            $0.top.equalTo(contentView)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(contentView).offset(-8)
+        }
+    }
+}

--- a/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/RecallPage/View/RecallView.swift
+++ b/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/RecallPage/View/RecallView.swift
@@ -59,11 +59,20 @@ class RecallView: UIView {
         $0.font = UIFont.subtitleFont()
     }
     
+    private let privateButton = UIButton().then {
+        $0.setImage(ImageLiterals.RecallProperty.defaultRecall, for: .normal)
+    }
+    
+    
     // MARK: - Initialization
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupViews()
+        recallTextView.delegate = self
+        bestTextView.delegate = self
+        wantsayTextView.delegate = self
+ 
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -81,26 +90,32 @@ class RecallView: UIView {
             wantsayTextView,
             recallLabel,
             todayLabel,
-            saymeLabel
+            saymeLabel,
+            privateButton
         )
         self.snp.makeConstraints {
-                $0.height.equalTo(495)
+            $0.height.equalTo(495)
+        }
+        
+        privateButton.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(18)
+            $0.bottom.equalTo(recallTextView.snp.top).offset(-10)
         }
         
         recallTextView.snp.makeConstraints {
-            $0.width.equalTo(375)
+            $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(118)
             $0.top.equalToSuperview().offset(55)
         }
         
         bestTextView.snp.makeConstraints {
-            $0.width.equalTo(375)
+            $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(118)
             $0.top.equalTo(recallTextView.snp.bottom).offset(50)
         }
         
         wantsayTextView.snp.makeConstraints {
-            $0.width.equalTo(375)
+            $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(118)
             $0.top.equalTo(bestTextView.snp.bottom).offset(50)
         }
@@ -121,3 +136,49 @@ class RecallView: UIView {
         }
     }
 }
+
+
+extension RecallView: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView == recallTextView {
+            if textView.textColor == .Gray.gray_400 {
+                textView.text = nil
+                textView.textColor = .black
+            }
+        } else if textView == bestTextView {
+            if textView.textColor == .Gray.gray_400 {
+                textView.text = nil
+                textView.textColor = .black
+            }
+        }
+        else if textView == wantsayTextView {
+            if textView.textColor == .Gray.gray_400 {
+                textView.text = nil
+                textView.textColor = .black
+            }
+        }
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView == recallTextView {
+            if textView.text.isEmpty {
+                textView.text = "오늘 루틴 어땠어요?"
+                textView.textColor = UIColor.Gray.gray_400
+            }
+        } else if textView == bestTextView {
+            if textView.text.isEmpty {
+                textView.text = "오늘은 뭐가 가장 좋았어요?"
+                textView.textColor = UIColor.Gray.gray_400
+            }
+        } else if textView == wantsayTextView {
+            if textView.text.isEmpty {
+                textView.text = "나에게 하고 싶은 말을 적어봐요 :)"
+                textView.textColor = UIColor.Gray.gray_400
+            }
+        }
+    }
+}
+
+
+
+

--- a/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/TotalRoutine/VC/TotalRoutineViewController.swift
+++ b/MY-SOPT-IN-iOS/MY-SOPT-IN-iOS/Presentation/TotalRoutine/VC/TotalRoutineViewController.swift
@@ -19,6 +19,8 @@ final class TotalRoutineViewController: UIViewController {
     private let backButton: UIButton = {
         let btn = UIButton()
         btn.setImage(ImageLiterals.Icon.add_ic_arrow, for: .normal)
+        btn.addTarget(self, action: #selector(popToTotalRoutineViewController), for: .touchUpInside)
+
         return btn
     }()
     
@@ -71,6 +73,11 @@ final class TotalRoutineViewController: UIViewController {
             modal.transitioningDelegate = self
             self.present(modal, animated: true)
         }
+    }
+    
+    @objc
+    private func popToTotalRoutineViewController() {
+        self.navigationController?.popViewController(animated: true)
     }
 }
 
@@ -197,6 +204,10 @@ extension TotalRoutineViewController: UITableViewDelegate, UITableViewDataSource
         view.editButtonTappedClosure = {[weak self] in
             print("edit")
             // 루틴 수정 뷰로
+            let editRecallViewController = EditRecallViewController()
+            editRecallViewController.hidesBottomBarWhenPushed = true
+            self?.navigationController?.pushViewController(editRecallViewController, animated: true)
+            
         }
         return view
     }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feat/#18

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
RecallView TableView로 전환
MainPageRecallViewController에 RecallView연결
MainPageRecallViewController에서 회고 모아보기 버튼 클릭시 TotalRoutineViewController로 화면전환
## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
TotalRoutineViewController에서 pop 미구현
TotalRoutineViewController에서 editButton 클릭시 EditRecallViewController로 뷰 이동 미구현
MainPageRecallViewController에서 스크롤 하면 위에 캘린더가 돌아갑니다


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/MY-SOPT-IN/MY-SOPT-IN-iOS/assets/38289956/c0bfd58c-49ff-44b7-a50a-907cfaf63270" width ="250">|

## 📟 관련 이슈
- Resolved: #18 
